### PR TITLE
Update Markdown output to match linter now used in NUnit docs

### DIFF
--- a/GetChanges/Program.cs
+++ b/GetChanges/Program.cs
@@ -44,9 +44,9 @@ namespace Alteridem.GetChanges
             foreach (var issue in issues)
             {
                 if(options.LinkIssues)
-                    Console.WriteLine($" * [{issue.Number:####}](https://github.com/{options.Organization}/{options.Repository}/issues/{issue.Number}) {issue.Title}");
+                    Console.WriteLine($"* [{issue.Number:####}](https://github.com/{options.Organization}/{options.Repository}/issues/{issue.Number}) {issue.Title}");
                 else
-                    Console.WriteLine($" * {issue.Number:####} {issue.Title}");
+                    Console.WriteLine($"* {issue.Number:####} {issue.Title}");
             }
             Console.WriteLine();
         }


### PR DESCRIPTION
The linter for the new NUnit docs site expects no space before unordered list bullets.

@rprouse - not sure if you use this tool for anything other than NUnit, which might make this a consistency issue? Feel free to close if so. 